### PR TITLE
Fixed bug reports: BR001, BR002, BR003, BR004

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
     <div id="content-wrapper">
         <header>
             <div id="logo-container">
-                <img src="images/logo.webp" alt="Logo" id="logo">
+                <a href="index.html">
+                    <img src="images/logo.webp" alt="Logo" id="logo">
+                </a>
                 <h1>Discover amazing images from around the world!</h1>
             </div>
             <input type="text" id="search-bar" placeholder="Search for images...">

--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ function debounce(func, wait) {
 }
 
 function fetchRandomImages() {
-    const url = `https://api.unsplash.com/photos?client_id=${accessKey}&page=${page}&per_page=10`;
+    const url = `https://api.unsplash.com/photos?client_id=${accessKey}&page=${page}&per_page=30`;
     document.getElementById('loading-indicator').classList.remove('hidden');
     isLoading = true;
     fetch(url)
@@ -53,7 +53,7 @@ function fetchRandomImages() {
 }
 
 function searchImages(query) {
-    const url = `https://api.unsplash.com/search/photos?query=${query}&client_id=${accessKey}&page=${page}&per_page=10`;
+    const url = `https://api.unsplash.com/search/photos?query=${query}&client_id=${accessKey}&page=${page}&per_page=30`;
     document.getElementById('loading-indicator').classList.remove('hidden');
     isLoading = true;
     fetch(url)
@@ -98,6 +98,7 @@ function showImageDetails(image) {
 
 function closeImageDetails() {
     document.getElementById('image-details').classList.add('hidden');
+    document.getElementById('content-wrapper').classList.remove('blurred');
     document.getElementById('modal-overlay').classList.add('hidden');
     
     document.body.style.overflow = 'auto';

--- a/styles.css
+++ b/styles.css
@@ -145,9 +145,9 @@ h1 {
     margin-bottom: 10px;
 }
 
-
 #details-image {
     max-width: 100%;
+    max-height: 80%;
     border-radius: 5px;
     object-fit: contain;
 }


### PR DESCRIPTION
BR001:

Steps to resolve the issue:

Increase the number of images loaded on the initial page load to ensure a scrollbar is present, enabling immediate scrolling.
Test across different devices and browsers to ensure consistent behavior and responsiveness.

`const url = https://api.unsplash.com/photos?client_id=${accessKey}&page=${page}&per_page=30; `

In this case, `per_page=30` resolved the issue, as now on the initial load there are 30 images and the vertical scrollbar is present right away.


BR002:

Steps to resolve the issue:

Make sure the `blurred `class is removed from the main content container when closing the image detail modal.

Update the `closeImageDetails` JavaScript function to remove the blur effect from the content area.

Add this code to the function:

`document.getElementById('content-wrapper').classList.remove('blurred');`


BR003:

Steps to resolve the issue:

My logo image wasn’t wrapped into an a tag with the link to homepage, that’s why when users click on logo it didn’t direct them to homepare.


Change this code:
```
<div id="logo-container">

<img src="images/logo.webp" alt="Logo" id="logo">

<h1>Discover amazing images from around the world!</h1>

</div>
```


To this code:
```
<div id="logo-container">

<a href="index.html">

<img src="images/logo.webp" alt="Logo" id="logo">

</a>

<h1>Discover amazing images from around the world!</h1>

</div>
```

BR004:

Steps to resolve the issue:

Research the CSS rule that controls the size of the image in the modal.

Add or update the CSS rule to:

```
#details-image {

    max-height: 80%;

}
```

Ensure the new CSS rule is applied correctly across all configurations.

Test the modal to verify that the images are now displayed at an appropriate size and no longer cover the text.