### PR TITLE
Addressed the following bug reports: BR008, BR009, BR010

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,7 +93,7 @@ function showImageDetails(image) {
     document.body.style.overflow = 'hidden';
 
     document.getElementById('modal-overlay').addEventListener('click', closeImageDetails);
-    document.getElementById('close-detail').addEventListener('click', closeImageDetails);
+    document.getElementById('close-details').addEventListener('click', closeImageDetails);
 }
 
 function closeImageDetails() {

--- a/styles.css
+++ b/styles.css
@@ -38,7 +38,7 @@ h1 {
 }
 
 #search-bar {
-    width: 700px;
+    width: 50%;
     padding: 10px;
     margin-top: 10px;
     border: none;
@@ -60,6 +60,10 @@ h1 {
     cursor: pointer;
 }
 
+#search-button:hover {
+    background-color: #0056b3;
+}
+
 #image-gallery {
     display: flex;
     flex-wrap: wrap;
@@ -71,8 +75,8 @@ h1 {
     margin: 10px;
     border-radius: 5px;
     overflow: hidden;
-    transition: transform 0.2s;
     cursor: pointer;
+    transition: transform 0.2s;
 }
 
 .image-card:hover {
@@ -144,8 +148,12 @@ h1 {
     border: none;
     padding: 10px;
     border-radius: 5px;
-    margin-bottom: 10px;
     cursor: pointer;
+    margin-bottom: 10px;
+}
+
+#close-details:hover {
+    background-color: rgb(223, 63, 63);
 }
 
 #details-image {


### PR DESCRIPTION
**Bug report BR008:**

Steps to resolve the issue:

Find the CSS rule that sets the width of the search bar.
Change the code from:
```
#search-bar {
width: 700px;
}
```

To:
```
#search-bar {
width: 50%;
}
```

Apply the fix and ensure that the search bar resizes proportionally across different screen sizes.
Test the app on various devices and screen sizes to verify that the search bar is now responsive and functions correctly.


**Bug report BR009:**

Steps to resolve the issue:

The following CSS rules were added to fix the button hover states:
```
#close-details:hover {
background-color: rgb(223, 63, 63);
}
```

```
#search-button:hover {
background-color: #0056b3;
}
```

This change was implemented and tested across different devices and browsers to ensure that the buttons now provide the correct visual feedback when hovered.


**Bug report BR010:**

Steps to resolve the issue:

The bug was caused by a typo in the JavaScript code where the id of the close button was incorrectly referenced.
Console Error: Before the fix, the following error was observed in the console:
```
TypeError: Cannot read properties of null (reading 'addEventListener')

at showImageDetails (script.js:96:44)

at HTMLDivElement.<anonymous> (script.js:78:51)

```
The original code was:
```
function showImageDetails(image) {
document.getElementById('close-detail').addEventListener('click', closeImageDetails);
}
```

The typo in the id was corrected by changing close-detail to close-details:
```
function showImageDetails(image) {
document.getElementById('close-details').addEventListener('click', closeImageDetails);
}
```

After making this change, the close button started working, allowing users to close the modal as they would expect.